### PR TITLE
Reducing strict dependency on naming conventions

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -6,6 +6,6 @@
     "access": "public"
   },
   "plugins": {
-    "release-it-plugin-esm-bundle": {}
+    "./customized-esm-bundle-plugin.js": {}
   }
 }

--- a/customized-esm-bundle-plugin.js
+++ b/customized-esm-bundle-plugin.js
@@ -1,0 +1,32 @@
+const path = require("path");
+const Plugin = require("release-it/lib/plugin/Plugin.js");
+const packageJson = require(path.join(process.cwd(), "./package.json"));
+
+module.exports = class CustomVersion extends Plugin {
+  static disablePlugin() {
+    const depVersion = getDepVersion();
+    const currentPackageVersion = packageJson.version;
+
+    if (currentPackageVersion.startsWith(depVersion)) {
+      console.info(
+        "Disabling release-it because this version is already published"
+      );
+      return ["git", "github", "npm", "version"];
+    } else {
+      return [];
+    }
+  }
+  getIncrementedVersionCI() {
+    return getDepVersion();
+  }
+};
+
+function getDepVersion() {
+  const depName = "lodash-es";
+  const dependency = (packageJson.devDependencies || {})[depName];
+  if (!dependency) {
+    throw Error(`Missing package.json dependency '${depName}'`);
+  }
+
+  return /[0-9.]+/.exec(dependency)[0];
+}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "prettier": "2.2.1",
     "pretty-quick": "3.1.0",
     "release-it": "14.6.1",
-    "release-it-plugin-esm-bundle": "2.1.0",
     "rollup": "2.45.2",
     "rollup-plugin-terser": "7.0.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,6 @@ specifiers:
   prettier: 2.2.1
   pretty-quick: 3.1.0
   release-it: 14.6.1
-  release-it-plugin-esm-bundle: 2.1.0
   rollup: 2.45.2
   rollup-plugin-terser: 7.0.2
 
@@ -32,7 +31,6 @@ devDependencies:
   prettier: 2.2.1
   pretty-quick: 3.1.0_prettier@2.2.1
   release-it: 14.6.1
-  release-it-plugin-esm-bundle: 2.1.0
   rollup: 2.45.2
   rollup-plugin-terser: 7.0.2_rollup@2.45.2
 
@@ -4555,10 +4553,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       rc: 1.2.8
-    dev: true
-
-  /release-it-plugin-esm-bundle/2.1.0:
-    resolution: {integrity: sha512-AWnkgV488lCVqrUX69PppbdtfuHANXBPIpozr9NbjNp+MZTKtFeBvu8+bSwzxY3EUn0vCOa3MEXTi15eUc+d3A==}
     dev: true
 
   /release-it/14.6.1:


### PR DESCRIPTION
This odd behavior is pretty custom to lodash

Basically I had issues with trying to re-export everything with requirejs related to how the newest version of requireJS doesn't magically create the named exports for you.

So I cheated and used `lodash-es` as the foundation. That works great for the build but caused issues with the reusable plugin. 

One way to fix #32 

## Alternatives I considered

### Modify the plugin to work with this odd behavior.

I didn't like this solution as it felt very weird to add a custom use case that so far only affects one module to the `release-it-plugin-esm-bundle`

## Why this matters

So far we've been _potentially_ publishing the wrong code under the wrong version number. We've had a hidden race condition where depending on what was updated automatically/when it was possible to update `lodash` in the deps array but not `lodash-es` resulting in a "bad" bundle. So far this hasn't bit us but it probably will in the future.